### PR TITLE
Add support for installation by Mint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,9 @@ import PackageDescription
 let package = Package(
     name: "CreateAPI",
     platforms: [.macOS(.v10_15)],
+    products: [
+        .executable(name: "create-api", targets: ["CreateAPI"])
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.0.1"),
         .package(url: "https://github.com/kean/OpenAPIKit", branch: "create-api"),

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Delightful code generation for OpenAPI specs for Swift written in Swift.
 
 ## Installation
 
+### [Mint](https://github.com/yonaskolb/Mint)
+
+```bash
+mint install kean/CreateAPI
+```
+
+Usage:
+
+```bash
+mint run CreateAPI create-api generate -h
+```
+
 ### Make
 
 ```bash


### PR DESCRIPTION
I would like to add support for installation by [Mint](https://github.com/yonaskolb/Mint) to make it easier to use the tool.

* Add executable product to products in `Package.swift` to allow installation by Mint
* Add description for how to install by Mint