### PR TITLE
Add Entities.include

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ isSwiftLintDisabled: true
 fileHeader: null
 
 entities:
-  # Skipped entities, e.g. ["SimpleUser"]
-  skip: []
+  # Excluded entities, e.g. ["SimpleUser"]
+  # `exclude` and `include` can't be used together
+  exclude: []
+  # Included entities, e.g. ["SimpleUser"]
+  include: []
   # Generates entities as structs
   isGeneratingStructs: true
   # Generate the following entities as classes

--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ comments:
 
 The goal is to completely cover OpenAPI 3.x spec. 
 
-Currency the following features are **not** supported:
+Currently, the following features are **not** supported:
 
 - External References
 
 Some discrepancies with the OpenAPI spec are by design:
 
 - `allowReserved` keyword in parameters is ignored and all parameter values are percent-encoded
-- `allowEmptyValue` keyword in parameters is ignored as its not recommended to be used
+- `allowEmptyValue` keyword in parameters is ignored as it's not recommended to be used
 
 Upcoming:
 

--- a/Sources/CreateAPI/GenerateOptions.swift
+++ b/Sources/CreateAPI/GenerateOptions.swift
@@ -121,6 +121,8 @@ final class GenerateOptions {
         var entities: [String: String]
         var operations: [String: String]
         var collectionElements: [String: String]
+        var entityPrefix: String?
+        var entitySuffix: String?
         
         init(_ options: GenerateOptionsSchema.Rename?) {
             self.properties = options?.properties ?? [:]
@@ -129,6 +131,8 @@ final class GenerateOptions {
             self.entities = options?.entities ?? [:]
             self.operations = options?.operations ?? [:]
             self.collectionElements = options?.collectionElements ?? [:]
+            self.entityPrefix = options?.entityPrefix
+            self.entitySuffix = options?.entitySuffix
         }
     }
     
@@ -238,6 +242,8 @@ final class GenerateOptionsSchema: Decodable {
         var entities: [String: String]?
         var operations: [String: String]?
         var collectionElements: [String: String]?
+        var entityPrefix: String?
+        var entitySuffix: String?
     }
     
     struct Comments: Decodable {

--- a/Sources/CreateAPI/GenerateOptions.swift
+++ b/Sources/CreateAPI/GenerateOptions.swift
@@ -54,7 +54,8 @@ final class GenerateOptions {
         var isAddingDefaultValues: Bool
         var isInliningPropertiesFromReferencedSchemas: Bool
         var isAdditionalPropertiesOnByDefault: Bool
-        var skip: Set<String>
+        var exclude: Set<String>
+        var include: Set<String>
         
         init(_ options: GenerateOptionsSchema.Entities?) {
             self.isGeneratingStructs = options?.isGeneratingStructs ?? true
@@ -72,7 +73,8 @@ final class GenerateOptions {
             self.isAddingDefaultValues = options?.isAddingDefaultValues ?? true
             self.isInliningPropertiesFromReferencedSchemas = options?.isInliningPropertiesFromReferencedSchemas ?? false
             self.isAdditionalPropertiesOnByDefault = options?.isAdditionalPropertiesOnByDefault ?? true
-            self.skip = Set(options?.skip ?? [])
+            self.exclude = Set(options?.exclude ?? [])
+            self.include = Set(options?.include ?? [])
         }
     }
     
@@ -216,7 +218,8 @@ final class GenerateOptionsSchema: Decodable {
         var isAddingDefaultValues: Bool?
         var isInliningPropertiesFromReferencedSchemas: Bool?
         var isAdditionalPropertiesOnByDefault: Bool?
-        var skip: [String]?
+        var exclude: [String]?
+        var include: [String]?
     }
     
     struct Paths: Decodable {

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -90,7 +90,7 @@ extension Generator {
                     continue
                 }
             } else {
-                guard options.entities.exclude.contains(name.rawValue) else {
+                guard !options.entities.exclude.contains(name.rawValue) else {
                     if arguments.isVerbose {
                         print("Skipping generation for \(key.rawValue)")
                     }

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -86,7 +86,7 @@ extension Generator {
                 continue
             }
             if !options.entities.include.isEmpty {
-                guard !options.entities.include.contains(name.rawValue) else {
+                guard options.entities.include.contains(name.rawValue) else {
                     continue
                 }
             } else {

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -90,7 +90,7 @@ extension Generator {
                     continue
                 }
             } else {
-                guard !options.entities.exclude.contains(name.rawValue) else {
+                guard options.entities.exclude.contains(name.rawValue) else {
                     if arguments.isVerbose {
                         print("Skipping generation for \(key.rawValue)")
                     }


### PR DESCRIPTION
Hello :)

## What

While implementing this plugin into our project, I found that `Entities.skip` is very hard to maintain.
Therefore, I'd like to implement `include` which works completely opposite way from `skip`.

## Background

We are currently just replacing hard-coded entities with CreateAPI generated entities, but of course, it is difficult to replace hundreds of entities at once. Therefore, we plan to replace them gradually. In this context, `include` is much more useful than `skip`.

## Changes
- Renamed `skip` to `exclude` to provide a kind of consistency with `include`. If you have any other suggestions, please :)
- Added `include`
- Throw error when both of `include` and `exclude` have value.