### PR TITLE
Revert "Added entityPrefix and entitySuffix to GenerateOptions.Rename"

### DIFF
--- a/Sources/CreateAPI/GenerateOptions.swift
+++ b/Sources/CreateAPI/GenerateOptions.swift
@@ -123,8 +123,6 @@ final class GenerateOptions {
         var entities: [String: String]
         var operations: [String: String]
         var collectionElements: [String: String]
-        var entityPrefix: String?
-        var entitySuffix: String?
         
         init(_ options: GenerateOptionsSchema.Rename?) {
             self.properties = options?.properties ?? [:]
@@ -133,8 +131,6 @@ final class GenerateOptions {
             self.entities = options?.entities ?? [:]
             self.operations = options?.operations ?? [:]
             self.collectionElements = options?.collectionElements ?? [:]
-            self.entityPrefix = options?.entityPrefix
-            self.entitySuffix = options?.entitySuffix
         }
     }
     
@@ -245,8 +241,6 @@ final class GenerateOptionsSchema: Decodable {
         var entities: [String: String]?
         var operations: [String: String]?
         var collectionElements: [String: String]?
-        var entityPrefix: String?
-        var entitySuffix: String?
     }
     
     struct Comments: Decodable {


### PR DESCRIPTION
This reverts commit 324ab3e6f87d6204571204332f7ca6270c10d79d.
[Former PR](https://github.com/kean/CreateAPI/pull/5) contained unintentional change which I was working on different PR. Sorry 😢 