### PR TITLE
Discriminator Support

### DIFF
--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -198,6 +198,8 @@ final class EntityDeclaration: Declaration {
     
     var protocols = Protocols()
     var properties: [Property] = []
+    var discriminator: Discriminator?
+
     var isRenderedAsStruct = false
     weak var parent: EntityDeclaration?
     
@@ -205,11 +207,12 @@ final class EntityDeclaration: Declaration {
         properties.compactMap { $0.nested }
     }
     
-    init(name: TypeName, type: EntityType, metadata: DeclarationMetadata, isForm: Bool, parent: EntityDeclaration? = nil) {
+    init(name: TypeName, type: EntityType, metadata: DeclarationMetadata, isForm: Bool, discriminator: Discriminator? = nil, parent: EntityDeclaration? = nil) {
         self.name = name
         self.type = type
         self.metadata = metadata
         self.isForm = isForm
+        self.discriminator = discriminator
         self.parent = parent
     }
     
@@ -238,6 +241,11 @@ struct TypealiasDeclaration: Declaration {
     let name: TypeName
     var type: TypeIdentifier
     var nested: Declaration?
+}
+
+struct Discriminator {
+    let propertyName: String
+    let mapping: [String: TypeIdentifier]
 }
 
 struct DeclarationMetadata {

--- a/Sources/CreateAPI/Generator/Generator+Render.swift
+++ b/Sources/CreateAPI/Generator/Generator+Render.swift
@@ -94,7 +94,11 @@ extension Generator {
                 }
             case .oneOf:
                 if decl.protocols.isDecodable {
-                    contents.append(templates.initFromDecoderOneOf(properties: properties))
+                    if let discriminator = decl.discriminator {
+                        contents.append(templates.initFromDecoderOneOfWithDiscriminator(properties: properties, discriminator: discriminator))
+                    } else {
+                        contents.append(templates.initFromDecoderOneOf(properties: properties))
+                    }
                 }
                 if decl.protocols.isEncodable {
                     contents.append(templates.encodeOneOf(properties: properties))

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -409,17 +409,22 @@ extension Generator {
         }
     }
 
-    private func makeDiscriminator(info: JSONSchemaContext, context: Context) -> Discriminator? {
+    private func makeDiscriminator(info: JSONSchemaContext, context: Context) throws -> Discriminator? {
         if let discriminator = info.discriminator {
             var mapping: [String: TypeIdentifier] = [:]
 
             if let innerMapping = discriminator.mapping {
-                
-                // TODO: Use type name machinery instead
-                mapping = innerMapping.mapValues { value in 
-                    return .userDefined(
-                        name: makeTypeName(String(value.dropFirst("#/components/schemas/".count)))
-                    )
+                for (key, value) in innerMapping {
+                    let stripped = String(value.dropFirst("#/components/schemas/".count))
+                    guard let componentKey = OpenAPI.ComponentKey(rawValue: stripped) else {
+                        throw GeneratorError("Encountered invalid type name \"\(value)\" while constructing discriminator")
+                    }
+
+                    if let name = getTypeName(for: componentKey) {
+                        mapping[key] = .userDefined(name: name)
+                    } else {
+                        try handle(warning: "Mapping \"\(key)\" has no matching type")
+                    }
                 }
             }
 
@@ -440,7 +445,6 @@ extension Generator {
             type: type, 
             metadata: DeclarationMetadata(info), 
             isForm: context.isFormEncoding,
-            discriminator: makeDiscriminator(info: info, context: context),
             parent: context.parents.last
         )
         let context = context.map { $0.parents.append(entity) }
@@ -468,6 +472,8 @@ extension Generator {
             return protocols
         }()
         
+        entity.discriminator = try makeDiscriminator(info: info, context: context)
+
         // Covers a weird case encountered in open-banking.yaml spec (xml-sct schema)
         // TODO: We can potentially inline this instead of creating a typealias
         if entity.properties.count == 1, entity.properties[0].nested == nil {

--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -313,9 +313,8 @@ final class Templates {
         for property in properties {
             if let correspondingMapping = discriminator.mapping.first(where: { $1 == property.type}) {
                 statements += """
+                case \"\(correspondingMapping.key)\": self = .\(property.name)(try container.decode(\(property.type).self))
 
-                case .some(let inner) where inner.\(discriminator.propertyName) == \"\(correspondingMapping.key)\":
-                    self = .\(property.name)(try container.decode(\(property.type).self))
                 """
             } else {
                 continue
@@ -338,7 +337,7 @@ final class Templates {
 
             let container = try decoder.singleValueContainer()
 
-            switch try? container.decode(Discriminator.self) {
+            switch (try container.decode(Discriminator.self)).\(discriminator.propertyName) {
         \(statements.indented)
         }
         """

--- a/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/discriminator/Sources/Entities.swift
@@ -45,13 +45,11 @@ public struct Container: Codable {
 
             let container = try decoder.singleValueContainer()
 
-            switch try? container.decode(Discriminator.self) {
-            case .some(let inner) where inner.kind == "a":
-                self = .a(try container.decode(A.self))
-            case .some(let inner) where inner.kind == "b":
-                self = .b(try container.decode(B.self))
-            case .some(let inner) where inner.kind == "c":
-                self = .c(try container.decode(C.self))
+            switch (try container.decode(Discriminator.self)).kind {
+            case "a": self = .a(try container.decode(A.self))
+            case "b": self = .b(try container.decode(B.self))
+            case "c": self = .c(try container.decode(C.self))
+
             default:
                 throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to initialize `oneOf`")
             }

--- a/Tests/CreateAPITests/GenerateTests.swift
+++ b/Tests/CreateAPITests/GenerateTests.swift
@@ -14,6 +14,10 @@ final class GenerateTests: GenerateBaseTests {
     func testEdgecases() throws {
         try testSpec(name: "edgecases", package: "edgecases-default")
     }
+
+    func testDiscriminator() throws {
+        try testSpec(name: "discriminator", package: "discriminator")
+    }    
     
     func testGitHub() throws {
         // GIVEN

--- a/Tests/CreateAPITests/Specs/discriminator.yaml
+++ b/Tests/CreateAPITests/Specs/discriminator.yaml
@@ -1,0 +1,55 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Discriminator
+
+paths:
+  /container:
+    get:
+      responses:
+        "200":
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Container"
+components:
+  schemas:
+    A:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+    B:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+    C:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+
+    Container:
+      type: object
+      required:
+        - content
+      properties:
+        content:
+          oneOf:
+            - $ref: "#/components/schemas/A"
+            - $ref: "#/components/schemas/B"
+            - $ref: "#/components/schemas/C"
+          discriminator:
+            propertyName: kind
+            mapping:
+              a: "#/components/schemas/A"
+              b: "#/components/schemas/B"
+              c: "#/components/schemas/C"


### PR DESCRIPTION
Adds initial support for decoding `oneOf` entities with a [discriminator](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/) attribute.

Using the existing property type name machinery when constructing the discriminator is still outstanding. 
Would really appreciate some help with that, because I struggled to find a clean way to call into one of the name canonicalization functions.

<details>
	<summary>Generated Code</summary>

```swift
public struct A: Codable {
    public var kind: String

    public init(kind: String) {
        self.kind = kind
    }
}

public struct B: Codable {
    public var kind: String

    public init(kind: String) {
        self.kind = kind
    }
}

public struct C: Codable {
    public var kind: String

    public init(kind: String) {
        self.kind = kind
    }
}

public struct Container: Codable {
    public var content: Content

    public enum Content: Codable {
        case a(A)
        case b(B)
        case c(C)

        public init(from decoder: Decoder) throws {

            struct Discriminator: Decodable {
                let kind: String
            }

            let container = try decoder.singleValueContainer()

            switch try? container.decode(Discriminator.self) {
            case .some(let inner) where inner.kind == "a":
                self = .a(try container.decode(A.self))
            case .some(let inner) where inner.kind == "b":
                self = .b(try container.decode(B.self))
            case .some(let inner) where inner.kind == "c":
                self = .c(try container.decode(C.self))
            default:
                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Failed to initialize `oneOf`")
            }
        }

        public func encode(to encoder: Encoder) throws {
            var container = encoder.singleValueContainer()
            switch self {
            case .a(let value): try container.encode(value)
            case .b(let value): try container.encode(value)
            case .c(let value): try container.encode(value)
            }
        }
    }

    public init(content: Content) {
        self.content = content
    }
}

struct StringCodingKey: CodingKey, ExpressibleByStringLiteral {
    private let string: String
    private var int: Int?

    var stringValue: String { return string }

    init(string: String) {
        self.string = string
    }

    init?(stringValue: String) {
        self.string = stringValue
    }

    var intValue: Int? { return int }

    init?(intValue: Int) {
        self.string = String(describing: intValue)
        self.int = intValue
    }

    init(stringLiteral value: String) {
        self.string = value
    }
}
```
</details>

<details>
	<summary>Schema</summary>

```yaml
openapi: "3.0.0"
info:
  version: 1.0.0
  title: Discriminator

paths:
  /container:
    get:
      responses:
        "200":
          description: ""
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/Container"
components:
  schemas:
    A:
      type: object
      required:
        - kind
      properties:
        kind:
          type: string
    B:
      type: object
      required:
        - kind
      properties:
        kind:
          type: string
    C:
      type: object
      required:
        - kind
      properties:
        kind:
          type: string

    Container:
      type: object
      required:
        - content
      properties:
        content:
          oneOf:
            - $ref: "#/components/schemas/A"
            - $ref: "#/components/schemas/B"
            - $ref: "#/components/schemas/C"
          discriminator:
            propertyName: kind
            mapping:
              a: "#/components/schemas/A"
              b: "#/components/schemas/B"
              c: "#/components/schemas/C"
```
</details>