### PR TITLE
Use builtin `UUID` type for `uuid` format in schemas

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -231,7 +231,10 @@ extension Generator {
             setNaiveDateNeeded()
             return .builtin("NaiveDate")
         }
-        case .other(let other): if other == "uri" { return .builtin("URL") }
+        case .other(let other) where other == "uri": 
+            return .builtin("URL")
+        case .other(let other) where other == "uuid":
+            return .builtin("UUID")
         default: break
         }
         return .builtin("String")


### PR DESCRIPTION
> Formats such as "email", "uuid", and so on, MAY be used even though undefined by this specification.
> — [Specification](https://swagger.io/specification/)

The builtin UUID type is already `Codable`, so unless I'm missing something this should just work. 

```swift
import Foundation

struct Model: Codable {
    let id: UUID
}

let json = """
{
    "id": "f44d74e7-a8ca-4d5d-9d7d-6b28fc28b552"
}
"""

let decoder = JSONDecoder()
let decoded = try! decoder.decode(Model.self, from: json.data(using: .utf8)!)

let encoder = JSONEncoder()
let encodedData = try! encoder.encode(decoded)
let encodedString = String(data: encodedData, encoding: .utf8)
```

