### PR TITLE
Fix tests

### DIFF
--- a/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-change-access-control/Sources/Entities.swift
@@ -272,10 +272,10 @@ import NaiveDate
     var binary: String?
     var date: NaiveDate
     var dateTime: Date?
-    var uuid: String?
+    var uuid: UUID?
     var password: String
 
-    init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -341,11 +341,11 @@ enum EnumClass: String, Codable, CaseIterable {
 }
 
  struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    var uuid: String?
+    var uuid: UUID?
     var dateTime: Date?
     var map: [String: Animal]?
 
-    init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-coding-keys/Sources/Entities.swift
@@ -386,10 +386,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -418,7 +418,7 @@ public struct FormatTest: Codable {
         self.binary = try values.decodeIfPresent(String.self, forKey: "binary")
         self.date = try values.decode(NaiveDate.self, forKey: "date")
         self.dateTime = try values.decodeIfPresent(Date.self, forKey: "dateTime")
-        self.uuid = try values.decodeIfPresent(String.self, forKey: "uuid")
+        self.uuid = try values.decodeIfPresent(UUID.self, forKey: "uuid")
         self.password = try values.decode(String.self, forKey: "password")
     }
 
@@ -505,11 +505,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map
@@ -517,7 +517,7 @@ public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.uuid = try values.decodeIfPresent(String.self, forKey: "uuid")
+        self.uuid = try values.decodeIfPresent(UUID.self, forKey: "uuid")
         self.dateTime = try values.decodeIfPresent(Date.self, forKey: "dateTime")
         self.map = try values.decodeIfPresent([String: Animal].self, forKey: "map")
     }

--- a/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-default/Sources/Entities.swift
@@ -272,10 +272,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -341,11 +341,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-acronyms/Sources/Entities.swift
@@ -263,10 +263,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -332,11 +332,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-disable-enums/Sources/Entities.swift
@@ -258,10 +258,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -315,11 +315,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-indent-with-two-width-spaces/Sources/Entities.swift
@@ -272,10 +272,10 @@ public struct FormatTest: Codable {
   public var binary: String?
   public var date: NaiveDate
   public var dateTime: Date?
-  public var uuid: String?
+  public var uuid: UUID?
   public var password: String
 
-  public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+  public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
     self.integer = integer
     self.int32 = int32
     self.int64 = int64
@@ -341,11 +341,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-  public var uuid: String?
+  public var uuid: UUID?
   public var dateTime: Date?
   public var map: [String: Animal]?
 
-  public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+  public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
     self.uuid = uuid
     self.dateTime = dateTime
     self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-int32-int64/Sources/Entities.swift
@@ -272,10 +272,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int32? = nil, int64: Int64? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int32? = nil, int64: Int64? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -341,11 +341,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename-properties/Sources/Entities.swift
@@ -293,10 +293,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -362,11 +362,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-rename/Sources/Entities.swift
@@ -272,10 +272,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -341,11 +341,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-tabs/Sources/Entities.swift
@@ -272,10 +272,10 @@ public struct FormatTest: Codable {
 	public var binary: String?
 	public var date: NaiveDate
 	public var dateTime: Date?
-	public var uuid: String?
+	public var uuid: UUID?
 	public var password: String
 
-	public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+	public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
 		self.integer = integer
 		self.int32 = int32
 		self.int64 = int64
@@ -341,11 +341,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-	public var uuid: String?
+	public var uuid: UUID?
 	public var dateTime: Date?
 	public var map: [String: Animal]?
 
-	public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+	public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
 		self.uuid = uuid
 		self.dateTime = dateTime
 		self.map = map

--- a/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/edgecases-yaml-config/Sources/Entities.swift
@@ -293,10 +293,10 @@ public struct FormatTest: Codable {
     public var binary: String?
     public var date: NaiveDate
     public var dateTime: Date?
-    public var uuid: String?
+    public var uuid: UUID?
     public var password: String
 
-    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: String? = nil, password: String) {
+    public init(integer: Int? = nil, int32: Int? = nil, int64: Int? = nil, number: Double, float: Double? = nil, double: Double? = nil, string: String? = nil, byte: String, binary: String? = nil, date: NaiveDate, dateTime: Date? = nil, uuid: UUID? = nil, password: String) {
         self.integer = integer
         self.int32 = int32
         self.int64 = int64
@@ -362,11 +362,11 @@ public struct AdditionalPropertiesClass: Codable {
 }
 
 public struct MixedPropertiesAndAdditionalPropertiesClass: Codable {
-    public var uuid: String?
+    public var uuid: UUID?
     public var dateTime: Date?
     public var map: [String: Animal]?
 
-    public init(uuid: String? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
+    public init(uuid: UUID? = nil, dateTime: Date? = nil, map: [String: Animal]? = nil) {
         self.uuid = uuid
         self.dateTime = dateTime
         self.map = map


### PR DESCRIPTION
After `UUID` support was introduced in 734a8e7e5173cb8bbbcc54346d950feccdb46077 the expected files became outdated.