### PR TITLE
Added imports option for entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ entities:
   # Strips the parent name of enum cases within objects that are `oneOf` / `allOf` / `anyOf` of nested references
   isStrippingParentNameInNestedObjects: false
   
+  # The types to import in the entities, by default empty
+  imports: ["CoreLocation"]
+  
 paths:
   # Excluded paths, e.g. ["/gists/{gist_id}/commits"]
   # `exclude` and `include` can't be used together

--- a/Sources/CreateAPI/GenerateOptions.swift
+++ b/Sources/CreateAPI/GenerateOptions.swift
@@ -41,6 +41,7 @@ final class GenerateOptions {
         var isGeneratingStructs: Bool
         var entitiesGeneratedAsClasses: Set<String>
         var entitiesGeneratedAsStructs: Set<String>
+        var imports: Set<String>
         var isMakingClassesFinal: Bool
         var baseClass: String?
         var protocols: Set<String>
@@ -64,6 +65,7 @@ final class GenerateOptions {
             self.isGeneratingStructs = options?.isGeneratingStructs ?? true
             self.entitiesGeneratedAsClasses = Set(options?.entitiesGeneratedAsClasses ?? [])
             self.entitiesGeneratedAsStructs = Set(options?.entitiesGeneratedAsStructs ?? [])
+            self.imports = Set(options?.imports ?? [])
             self.isMakingClassesFinal = options?.isMakingClassesFinal ?? true
             self.baseClass = options?.baseClass
             self.protocols = Set(options?.protocols ?? ["Codable"])
@@ -210,6 +212,7 @@ final class GenerateOptionsSchema: Decodable {
         var isGeneratingStructs: Bool?
         var entitiesGeneratedAsClasses: [String]?
         var entitiesGeneratedAsStructs: [String]?
+        var imports: Set<String>?
         var isMakingClassesFinal: Bool?
         var isGeneratingMutableClassProperties: Bool?
         var isGeneratingMutableStructProperties: Bool?

--- a/Sources/CreateAPI/Generator/Generator+Paths.swift
+++ b/Sources/CreateAPI/Generator/Generator+Paths.swift
@@ -37,7 +37,7 @@ extension Generator {
             }
         }
         return GeneratorOutput(
-            header: makeHeader(),
+            header: makeHeader(imports: makePathImports()),
             files: try generated.compactMap { $0 }.map { try $0.get() },
             extensions: makeExtensions()
         )
@@ -220,19 +220,11 @@ extension Generator {
     
     // MARK: - Misc
     
-    private func makeHeader() -> String {
-        var header = fileHeader
-        for value in makeImports().sorted() {
-            header += "\nimport \(value)"
-        }
-        return header
-    }
-    
-    private func makeImports() -> [String] {
+    private func makePathImports() -> Set<String> {
         var imports = options.paths.imports
         if isHTTPHeadersDependencyNeeded { imports.insert("HTTPHeaders") }
         if isQueryEncoderNeeded { imports.insert("URLQueryEncoder") }
-        return imports.sorted()
+        return imports
     }
     
     private func makeExtensions() -> GeneratedFile? {

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -61,7 +61,7 @@ extension Generator {
         }.compactMap { $0 }
    
         return GeneratorOutput(
-            header: fileHeader,
+            header: makeHeader(imports: options.entities.imports),
             files: files,
             extensions: makeExtensions()
         )

--- a/Sources/CreateAPI/Generator/Generator.swift
+++ b/Sources/CreateAPI/Generator/Generator.swift
@@ -46,6 +46,14 @@ final class Generator {
         TypeName(processing: rawValue, options: options)
     }
     
+    func makeHeader(imports: Set<String>) -> String {
+        var header = fileHeader
+        for value in imports.sorted() {
+            header += "\nimport \(value)"
+        }
+        return header
+    }
+    
     // MARK: State
     
     func setNeedsAnyJson() {

--- a/Tests/CreateAPITests/Expected/petstore-custom-imports/Sources/Entities.swift
+++ b/Tests/CreateAPITests/Expected/petstore-custom-imports/Sources/Entities.swift
@@ -4,6 +4,7 @@
 // swiftlint:disable all
 
 import Foundation
+import CoreLocation
 
 /// A pet title
 ///

--- a/Tests/CreateAPITests/GenerateOptionsTests.swift
+++ b/Tests/CreateAPITests/GenerateOptionsTests.swift
@@ -112,6 +112,9 @@ final class GenerateOptionsTests: GenerateBaseTests {
             {
                 "paths": {
                     "imports": ["Get", "HTTPHeaders", "CoreData"]
+                },
+                "entities": {
+                    "imports": ["CoreLocation"]
                 }
             }
             """)


### PR DESCRIPTION
As mentioned in https://github.com/kean/CreateAPI/issues/18#issuecomment-1031208978, this PR adds the `imports` option to the Entities.

**Why?**
Similar to the `paths.imports`,  this pretty much allows the user the import any modules in the generated entities files