### PR TITLE
Fix shouldGenerate check for entities.include option

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -101,10 +101,10 @@ extension Generator {
     
     private func shouldGenerate(name: String) -> Bool {
         if !options.entities.include.isEmpty {
-            return options.paths.include.contains(name)
+            return options.entities.include.contains(name)
         }
         if !options.entities.exclude.isEmpty {
-            return !options.paths.exclude.contains(name)
+            return !options.entities.exclude.contains(name)
         }
         return true
     }


### PR DESCRIPTION
While testing the upstream changes, entities defined in `entities.include` were skipped. I noticed `shouldGenerate` for entities option doesn't look right. I suppose it should have checked `options.entities.include` instead of `options.path.include` in `Generator+Schemas.swift`.

You can test it with any configurations that have `entities.include`. I believe entities defined in `entities.include` should not be skipped.

```yml
entities:
  isGeneratingStructs: true
  # Wanted to try this option!
  isGeneratingMutableStructProperties: false

  include:
    User
```