### PR TITLE
Fix `String` type with `byte` format

### DIFF
--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -242,6 +242,8 @@ extension Generator {
             return .builtin("URL")
         case .other(let other) where other == "uuid":
             return .builtin("UUID")
+        case .byte:
+          return .builtin("Data")
         default: break
         }
         return .builtin("String")


### PR DESCRIPTION
When the spec defines a string property with a byte format at the moment a `String` property is generated, but a `Data` property should  be generated instead.

With input:
```yaml
test_property:
  type: string
  format: byte
```

Before:
```swift
var testProperty: String
```

After:
```swift
var testProperty: Data
```