### PR TITLE
AnyJSON null support

### DIFF
--- a/Sources/CreateAPI/Generator/Templates.swift
+++ b/Sources/CreateAPI/Generator/Templates.swift
@@ -638,14 +638,16 @@ final class Templates {
     var anyJSON: String {
         """
         \(access)enum AnyJSON: Equatable, Codable {
+            case null
             case string(String)
             case number(Double)
             case object([String: AnyJSON])
             case array([AnyJSON])
             case bool(Bool)
 
-            var value: Any {
+            var value: Any? {
                 switch self {
+                case .null: return nil
                 case .string(let string): return string
                 case .number(let double): return double
                 case .object(let dictionary): return dictionary
@@ -657,6 +659,7 @@ final class Templates {
             \(access)func encode(to encoder: Encoder) throws {
                 var container = encoder.singleValueContainer()
                 switch self {
+                case .null: try container.encodeNil()
                 case let .array(array): try container.encode(array)
                 case let .object(object): try container.encode(object)
                 case let .string(string): try container.encode(string)
@@ -667,7 +670,9 @@ final class Templates {
 
             \(access)init(from decoder: Decoder) throws {
                 let container = try decoder.singleValueContainer()
-                if let object = try? container.decode([String: AnyJSON].self) {
+                if container.decodeNil() {
+                    self = .null
+                } else if let object = try? container.decode([String: AnyJSON].self) {
                     self = .object(object)
                 } else if let array = try? container.decode([AnyJSON].self) {
                     self = .array(array)

--- a/Tests/Support/Snapshots/OctoKit/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/OctoKit/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/discriminator/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Extensions/AnyJSON.swift
@@ -4,14 +4,16 @@
 import Foundation
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -23,6 +25,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -33,7 +36,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-change-access-control/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ enum AnyJSON: Equatable, Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ enum AnyJSON: Equatable, Codable {
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-coding-keys/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-data-types/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-data-types/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-default/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-default/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-acronyms/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-disable-enums/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-indent-with-two-width-spaces/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+  case null
   case string(String)
   case number(Double)
   case object([String: AnyJSON])
   case array([AnyJSON])
   case bool(Bool)
 
-  var value: Any {
+  var value: Any? {
     switch self {
+    case .null: return nil
     case .string(let string): return string
     case .number(let double): return double
     case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     switch self {
+    case .null: try container.encodeNil()
     case let .array(array): try container.encode(array)
     case let .object(object): try container.encode(object)
     case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
-    if let object = try? container.decode([String: AnyJSON].self) {
+    if container.decodeNil() {
+      self = .null
+    } else if let object = try? container.decode([String: AnyJSON].self) {
       self = .object(object)
     } else if let array = try? container.decode([AnyJSON].self) {
       self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-rename-properties/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-rename/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-rename/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-tabs/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-tabs/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+	case null
 	case string(String)
 	case number(Double)
 	case object([String: AnyJSON])
 	case array([AnyJSON])
 	case bool(Bool)
 
-	var value: Any {
+	var value: Any? {
 		switch self {
+		case .null: return nil
 		case .string(let string): return string
 		case .number(let double): return double
 		case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
 	public func encode(to encoder: Encoder) throws {
 		var container = encoder.singleValueContainer()
 		switch self {
+		case .null: try container.encodeNil()
 		case let .array(array): try container.encode(array)
 		case let .object(object): try container.encode(object)
 		case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
 	public init(from decoder: Decoder) throws {
 		let container = try decoder.singleValueContainer()
-		if let object = try? container.decode([String: AnyJSON].self) {
+		if container.decodeNil() {
+			self = .null
+		} else if let object = try? container.decode([String: AnyJSON].self) {
 			self = .object(object)
 		} else if let array = try? container.decode([AnyJSON].self) {
 			self = .array(array)

--- a/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Extensions/AnyJSON.swift
+++ b/Tests/Support/Snapshots/edgecases-yaml-config/Sources/Extensions/AnyJSON.swift
@@ -5,14 +5,16 @@ import Foundation
 import NaiveDate
 
 public enum AnyJSON: Equatable, Codable {
+    case null
     case string(String)
     case number(Double)
     case object([String: AnyJSON])
     case array([AnyJSON])
     case bool(Bool)
 
-    var value: Any {
+    var value: Any? {
         switch self {
+        case .null: return nil
         case .string(let string): return string
         case .number(let double): return double
         case .object(let dictionary): return dictionary
@@ -24,6 +26,7 @@ public enum AnyJSON: Equatable, Codable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
+        case .null: try container.encodeNil()
         case let .array(array): try container.encode(array)
         case let .object(object): try container.encode(object)
         case let .string(string): try container.encode(string)
@@ -34,7 +37,9 @@ public enum AnyJSON: Equatable, Codable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        if let object = try? container.decode([String: AnyJSON].self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let object = try? container.decode([String: AnyJSON].self) {
             self = .object(object)
         } else if let array = try? container.decode([AnyJSON].self) {
             self = .array(array)


### PR DESCRIPTION
Add support for `null` values in free-form JSON value.
```
{
    "decoded_body": {
        "query_id": 1690409533,
        "amount": "1000000000",
        "destination": "0:25603f6d7d3a1c6f981f02237c917150a6f2af971e83dd9e19605fa57a5d5b00",
        "response_destination": "0:25603f6d7d3a1c6f981f02237c917150a6f2af971e83dd9e19605fa57a5d5b00",
        "custom_payload": null,
        "forward_ton_amount": "1",
        "forward_payload": {
        "is_right": false,
        "value": "b5ee9c7201010101000300000140"
        }
    }
}
```