### PR TITLE
docs: remove dot-prefix in generate config-option

### DIFF
--- a/Docs/ConfigOptions.md
+++ b/Docs/ConfigOptions.md
@@ -110,11 +110,11 @@ Below you can find the complete documentation for all available options.
 ## generate
 
 **Type:** Set<Generate><br />
-**Default:** `[.entities, .paths, .enums, .package]`
+**Default:** `[entities, paths, enums, package]`
 
 Different components that CreateAPI should generate.
 
-Available options are `.entities`, `.paths`, `.enums` and `.package`.
+Available options are `entities`, `paths`, `enums` and `package`.
 Defaults to `[entities, paths, enums, package]`.
 
 <br/>


### PR DESCRIPTION
This PR changes the documentation to remove the dot-prefix when mentioning the generate config-options for the yaml.
I suppose the dot-prefix notation was used in v1?