### PR TITLE
fix: Discriminator respects useSwiftyPropertyNames

### DIFF
--- a/Sources/CreateAPI/Generator/Declarations.swift
+++ b/Sources/CreateAPI/Generator/Declarations.swift
@@ -239,7 +239,7 @@ struct TypealiasDeclaration: Declaration {
 }
 
 struct Discriminator {
-    let propertyName: String
+    let propertyName: PropertyName
     let mapping: [String: TypeIdentifier]
 
     func correspondingMappings(for property: Property) -> [(key: String, value: TypeIdentifier)] {

--- a/Sources/CreateAPI/Generator/Generator+Schemas.swift
+++ b/Sources/CreateAPI/Generator/Generator+Schemas.swift
@@ -402,7 +402,7 @@ extension Generator {
     private func makeDiscriminator(info: JSONSchemaContext, context: Context) throws -> Discriminator? {
         try info.discriminator.flatMap { discriminator in
             Discriminator(
-                propertyName: discriminator.propertyName,
+                propertyName: PropertyName(processing: discriminator.propertyName, options: options),
                 mapping: try discriminator.schemaMapping?.mapValues({ try getReferenceType($0, context: context) }) ?? [:]
             )
         }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/A.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/A.swift
@@ -4,19 +4,19 @@
 import Foundation
 
 public struct A: Codable {
-    public var kind: String
+    public var someKind: String
 
-    public init(kind: String) {
-        self.kind = kind
+    public init(someKind: String) {
+        self.someKind = someKind
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.kind = try values.decode(String.self, forKey: "kind")
+        self.someKind = try values.decode(String.self, forKey: "some_kind")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(kind, forKey: "kind")
+        try values.encode(someKind, forKey: "some_kind")
     }
 }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/AnotherContainer.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/AnotherContainer.swift
@@ -14,11 +14,11 @@ public struct AnotherContainer: Codable {
         public init(from decoder: Decoder) throws {
 
             struct Discriminator: Decodable {
-                let kind: String
+                let someKind: String
             }
 
             let container = try decoder.singleValueContainer()
-            let discriminatorValue = try container.decode(Discriminator.self).kind
+            let discriminatorValue = try container.decode(Discriminator.self).someKind
 
             switch discriminatorValue {
             case "one": self = .a(try container.decode(A.self))

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/B.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/B.swift
@@ -6,19 +6,19 @@ import Foundation
 public struct B: Codable {
     /// This is a description
     /// And it should be on multiple lines
-    public var kind: String
+    public var someKind: String
 
-    public init(kind: String) {
-        self.kind = kind
+    public init(someKind: String) {
+        self.someKind = someKind
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.kind = try values.decode(String.self, forKey: "kind")
+        self.someKind = try values.decode(String.self, forKey: "some_kind")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(kind, forKey: "kind")
+        try values.encode(someKind, forKey: "some_kind")
     }
 }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/C.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/C.swift
@@ -4,19 +4,19 @@
 import Foundation
 
 public struct C: Codable {
-    public var kind: String
+    public var someKind: String
 
-    public init(kind: String) {
-        self.kind = kind
+    public init(someKind: String) {
+        self.someKind = someKind
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.kind = try values.decode(String.self, forKey: "kind")
+        self.someKind = try values.decode(String.self, forKey: "some_kind")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(kind, forKey: "kind")
+        try values.encode(someKind, forKey: "some_kind")
     }
 }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/Container.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/Container.swift
@@ -14,11 +14,11 @@ public struct Container: Codable {
         public init(from decoder: Decoder) throws {
 
             struct Discriminator: Decodable {
-                let kind: String
+                let someKind: String
             }
 
             let container = try decoder.singleValueContainer()
-            let discriminatorValue = try container.decode(Discriminator.self).kind
+            let discriminatorValue = try container.decode(Discriminator.self).someKind
 
             switch discriminatorValue {
             case "a": self = .a(try container.decode(A.self))

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/Four.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/Four.swift
@@ -4,19 +4,19 @@
 import Foundation
 
 public struct Four: Codable {
-    public var kind: String
+    public var someKind: String
 
-    public init(kind: String) {
-        self.kind = kind
+    public init(someKind: String) {
+        self.someKind = someKind
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.kind = try values.decode(String.self, forKey: "kind")
+        self.someKind = try values.decode(String.self, forKey: "some_kind")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(kind, forKey: "kind")
+        try values.encode(someKind, forKey: "some_kind")
     }
 }

--- a/Tests/Support/Snapshots/discriminator/Sources/Entities/Three.swift
+++ b/Tests/Support/Snapshots/discriminator/Sources/Entities/Three.swift
@@ -4,23 +4,23 @@
 import Foundation
 
 public struct Three: Codable {
-    public var kind: String
+    public var someKind: String
     public var foo: String
 
-    public init(kind: String, foo: String) {
-        self.kind = kind
+    public init(someKind: String, foo: String) {
+        self.someKind = someKind
         self.foo = foo
     }
 
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: StringCodingKey.self)
-        self.kind = try values.decode(String.self, forKey: "kind")
+        self.someKind = try values.decode(String.self, forKey: "some_kind")
         self.foo = try values.decode(String.self, forKey: "foo")
     }
 
     public func encode(to encoder: Encoder) throws {
         var values = encoder.container(keyedBy: StringCodingKey.self)
-        try values.encode(kind, forKey: "kind")
+        try values.encode(someKind, forKey: "some_kind")
         try values.encode(foo, forKey: "foo")
     }
 }

--- a/Tests/Support/Specs/discriminator.yaml
+++ b/Tests/Support/Specs/discriminator.yaml
@@ -18,16 +18,16 @@ components:
     A:
       type: object
       required:
-        - kind
+        - some_kind
       properties:
-        kind:
+        some_kind:
           type: string
     B:
       type: object
       required:
-        - kind
+        - some_kind
       properties:
-        kind:
+        some_kind:
           type: string
           description: |
             This is a description
@@ -35,9 +35,9 @@ components:
     C:
       type: object
       required:
-        - kind
+        - some_kind
       properties:
-        kind:
+        some_kind:
           type: string
     One:
       allOf:
@@ -48,10 +48,10 @@ components:
     Three:
       type: object
       required:
-        - kind
+        - some_kind
         - foo
       properties:
-        kind:
+        some_kind:
           type: string
         foo:
           type: string
@@ -71,7 +71,7 @@ components:
             - $ref: "#/components/schemas/B"
             - $ref: "#/components/schemas/C"
           discriminator:
-            propertyName: kind
+            propertyName: some_kind
             mapping:
               a: "#/components/schemas/A"
               b: "#/components/schemas/B"
@@ -90,7 +90,7 @@ components:
             - $ref: "#/components/schemas/Three"
             - $ref: "#/components/schemas/Four"
           discriminator:
-            propertyName: kind
+            propertyName: some_kind
             mapping:
               one: "#/components/schemas/One"
               two: "#/components/schemas/Two"


### PR DESCRIPTION
JSON parsing for discriminators fails when the discriminator's `propertyName` has an `_` in it, and the default value of `swiftyPropertyNames` is true

this fix uses the `PropertyName` processing to respect the options passed into the generator  

in practice, a `JSONDecoder` with `.keyDecodingStrategy = .convertFromSnakeCase` set will fail to parse `some_kind` since it's looking for `someKind` instead.

this change will result in this being generated instead
```
             struct Discriminator: Decodable {
-                let some_kind: String
+                let someKind: String
             }
```